### PR TITLE
feat: add terminology config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,3 +180,7 @@ Currently, the game exclusively accommodates exactly two locations. You have the
 :warning: **Please exercise caution and refrain from modifying the "location_code" fields. Altering the default values ('hq', 'local') here can disrupt the application's functionality!** :warning:
 
 Changing the names of the locations in this section will solely impact how they are displayed in the header menu, tabs, and action titles. Role names (e.g., "HQ IT Team") remain distinct and should be configured separately within the **ROLES** table.
+
+## DICTIONARY
+
+You have the ability to modify the terminology associated with "polls" in this section. For instance, you can replace "poll" or "budget" with alternative words. To introduce a new synonym, simply edit the synonym column as needed.

--- a/migrations/20231025103613_create_dictionary_table.js
+++ b/migrations/20231025103613_create_dictionary_table.js
@@ -1,0 +1,11 @@
+exports.up = async (knex) => {
+  await knex.schema.createTable('dictionary', (tbl) => {
+    tbl.string('id').primary().notNullable();
+    tbl.string('word').notNullable();
+    tbl.string('synonym').notNullable();
+  });
+};
+
+exports.down = async (knex) => {
+  await knex.schema.dropTableIfExists('dictionary');
+};

--- a/src/app.js
+++ b/src/app.js
@@ -50,6 +50,11 @@ app.get('/locations', async (req, res) => {
   res.json(records);
 });
 
+app.get('/dictionary', async (req, res) => {
+  const records = await db('dictionary').select('word', 'synonym');
+  res.json(records);
+});
+
 app.get('/systems', async (req, res) => {
   const records = await db('system');
   res.json(records);

--- a/src/util/migrate.js
+++ b/src/util/migrate.js
@@ -95,6 +95,7 @@ async function migrate(accessToken, baseId) {
     fetchTable(base, 'event_types'),
     // fetch main tables
     fetchTable(base, 'locations'),
+    fetchTable(base, 'dictionary'),
     fetchTable(base, 'events'),
     fetchTable(base, 'purchased_mitigations'),
     fetchTable(base, 'responses'),
@@ -115,6 +116,7 @@ async function migrate(accessToken, baseId) {
     rawRecommendations,
     rawEventTypes,
     locations,
+    dictionary,
     injections, // = events
     mitigations, // = purchased_mitigations
     responses,
@@ -224,6 +226,7 @@ async function migrate(accessToken, baseId) {
   // sequential processing is important here as some tables rely on data from other tables to be already there
   const validatedSqlTables = await Promise.allSettled([
     validateForDb('location', locations),
+    validateForDb('dictionary', dictionary),
     validateForDb('injection', injections),
     validateForDb('mitigation', mitigations),
     validateForDb('response', responses),
@@ -242,6 +245,7 @@ async function migrate(accessToken, baseId) {
 
   const [
     sqlLocations,
+    sqlDictionary,
     sqlInjections,
     sqlMitigations,
     sqlResponses,
@@ -254,6 +258,7 @@ async function migrate(accessToken, baseId) {
   ] = validatedSqlTables.map((table) => table.value);
 
   await saveToDb('location', sqlLocations);
+  await saveToDb('dictionary', sqlDictionary);
   await saveToDb('injection', sqlInjections);
   await saveToDb('mitigation', sqlMitigations);
   await saveToDb('response', sqlResponses);

--- a/src/util/migration_schemas.js
+++ b/src/util/migration_schemas.js
@@ -26,6 +26,11 @@ const airtableSchemas = {
     name: yup.string(),
     location_code: yup.string().required().oneOf(locationsShort),
   }),
+  dictionary: yup.object({
+    id,
+    word: yup.string().required(),
+    synonym: yup.string().required(),
+  }),
   recommendations: yup.object({
     id,
     name: yup.string(),
@@ -138,6 +143,11 @@ const dbSchemas = {
     id,
     name: yup.string().required(),
     type: yup.string().oneOf(locationsShort).required(),
+  }),
+  dictionary: yup.object({
+    id,
+    word: yup.string().required(),
+    synonym: yup.string().required(),
   }),
   action: yup.object({
     id,


### PR DESCRIPTION
- Add terminology config options: introduce the "dictionary" table to provide synonyms for "budget" and "poll"